### PR TITLE
feat: add an option to customize the comment's title

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,17 @@ with:
   base_stats_path: '/path/to/my/stats.json'
   head_stats_path: '/path/to/my/stats.json'
   token: ${{ secrets.GITHUB_TOKEN }}
+  comment_title: 'Custom title'
 ```
 
 ## Inputs
 
-| Inputs          | Required | Default | Description                                                                                   |
-|-----------------|----------|---------|-----------------------------------------------------------------------------------------------|
-| base_stats_path | true     |         | Path to the Webpack generated "stats.json" file from the base branch.                         |
-| head_stats_path | true     |         | Path to the Webpack generated "stats.json" file from the head branch.                         |
-| token           | true     |         | Github token so the package can publish a comment in the pull-request when the diff is ready. |
+| Inputs          | Required | Default           | Description                                                                                   |
+|-----------------|----------|-------------------|-----------------------------------------------------------------------------------------------|
+| base_stats_path | true     |                   | Path to the Webpack generated "stats.json" file from the base branch.                         |
+| head_stats_path | true     |                   | Path to the Webpack generated "stats.json" file from the head branch.                         |
+| token           | true     |                   | Github token so the package can publish a comment in the pull-request when the diff is ready. |
+| comment_title   | false    |'Bundle difference'| Customized GitHub comment title.                                                              |
 
 ## Usage example
 

--- a/index.js
+++ b/index.js
@@ -57,11 +57,12 @@ async function run() {
       throw new Error('Cannot find the PR id.')
     }
 
+    const commentTitle = core.getInput('comment_title') || 'Bundle difference'
     await octokit.issues.createComment({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
       issue_number: pullRequestId,
-      body: `## Bundle difference
+      body: `## ${commentTitle}
 ${summaryTable}
 `
     })


### PR DESCRIPTION
In this PR I'm adding an option to customize the GitHub comment's title.