### PR TITLE
Modify webpack-stats-diff-action with some more granular functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webpack Stats Diff
 
-Creates a comment inside your Pull-Request with the difference between two Webpack stats files.
+this is a fork of Chronotruck's webpack-stats-diff-action. It creates a comment inside your Pull-Request with the difference between two Webpack stats files. Notably, this version shows the total at the top and a detailed breakdown file-by-file below that.
 
 ![Comment demo](./docs/splash.png)
 
@@ -9,14 +9,15 @@ Creates a comment inside your Pull-Request with the difference between two Webpa
 To use this Github action, in your steps you may have:
 
 ```yml
-uses: chronotruck/webpack-stats-diff-action@1.0.0
+uses: wistia/detailed-webpack-stats-diff-action@2.0.0
 with:
   base_stats_path: '/path/to/my/stats.json'
   head_stats_path: '/path/to/my/stats.json'
   token: ${{ secrets.GITHUB_TOKEN }}
   comment_title: 'Custom title'
-  announcement_percentage_threshold_increase: 0
-  announcement_percentage_threshold_decrease: -1.0
+  threshold: 1
+  extensions: js,css
+  all: true
 ```
 
 ## Inputs
@@ -27,8 +28,9 @@ with:
 | head_stats_path | true     |                   | Path to the Webpack generated "stats.json" file from the head branch.                         |
 | token           | true     |                   | Github token so the package can publish a comment in the pull-request when the diff is ready. |
 | comment_title   | false    |'Bundle difference'| Customized GitHub comment title.                                                              |
-| announcement_percentage_threshold_increase | false | undefined | Only announces bundle difference when the diff percentage increase exceeds this value.  The value should be a positive numeric value (integer or floating point) or zero. |
-| announcement_percentage_threshold_decrease | false | undefined | Only announces bundle difference when the diff percentage decrease exceeds this value. The value should be a negative numeric value (integer or floating point) or zero.|
+| threshold       | false    | 0                 | The minimum percentage increase/decrease in the diff bundle size for a comment to be added. passed directly to Number constructor.     |
+| extensions      | false    |                   | Extensions to filter to, in a comma-delineated string, with or without periods                |
+| all             | true     | false             | If you want to include files that didn't change, set this to 'true'                           |
 
 ## Usage example
 
@@ -104,7 +106,7 @@ Now, in a new job we can retrieve both of our saved stats from the artifacts and
       with:
         name: head-stats
     - name: Diff between base & head
-      uses: chronotruck/webpack-stats-diff-action@1.0.0
+      uses: wistia/detailed-webpack-stats-diff-action@2.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         base_stats_path: ./base-stats/stats.json
@@ -116,4 +118,3 @@ That's it! When the compare job will be executed, it will post a comment in the 
 ## License
 
 This project is licensed under MIT License.
-Open source time proudly sponsored by [Chronotruck](https://developers.chronotruck.com/?ref=github-webpack-stats-diff).

--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,17 @@ inputs:
   comment_title:
     description: 'Customized GitHub comment title.'
     required: false
-  announcement_percentage_threshold_increase:
-    description: 'The minimum percentage increase in the diff bundle size for a comment to be added. The percentage should use a positive number (integer or floating point) value or zero.'
+  threshold:
+    description: 'The minimum percentage increase/decrease in the diff bundle size for a comment to be added. passed directly to Number constructor.'
     required: false
-  announcement_percentage_threshold_decrease:
-    description: 'The minimum percentage decrease in the diff bundle size for a comment to be added. The percentage should use a negative numeric (integer or floating point) value or zero.'
+    default: '0'
+  extensions:
+    description: 'Extensions to filter to, in a comma-delineated string, with or without periods'
     required: false
+  all:
+    description: If you want to include files that didn't change, set this to 'true'
+    required: false
+    default: 'false'
 branding:
   icon: 'package'
   color: 'green'

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const { getStatsDiff } = require('webpack-stats-diff')
 const fileSize = require('filesize')
 const markdownTable = require('markdown-table')
 
-const doesPathExists = path => {
+const doesPathExist = path => {
   if (!fs.existsSync(path)) {
-    throw new Error(`${path} does not exist!`)
+    throw new Error(`${path} does not exist!`);
   }
 }
 
@@ -23,6 +23,15 @@ function createDiffRow(data) {
     fileSize(data.newSize), 
     `${fileSize(data.diff)} (${data.diffPercentage.toFixed(2)}%)`
   ];
+}
+
+// get assets from path to stats.json, using first child if there are multiple bundles
+function getAssets(path) {
+  const json = require(path);
+  if (json.children) {
+    return json.children[0].assets;
+  }
+  return json.assets;
 }
 
 async function run() {
@@ -47,15 +56,15 @@ async function run() {
       head: path.resolve(process.cwd(), statsPaths.head)
     }
 
-    doesPathExists(paths.base)
-    doesPathExists(paths.head)
+    doesPathExist(paths.base);
+    doesPathExist(paths.head);
 
     const assets = {
-      base: require(paths.base).assets,
-      head: require(paths.head).assets
+      base: getAssets(paths.base),
+      head: getAssets(paths.head)
     }
 
-    const diff = getStatsDiff(assets.base, assets.head, {extensions, threshold})
+    const diff = getStatsDiff(assets.base, assets.head, {extensions, threshold});
 
     console.log(diff);
 

--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ async function run() {
     ]);
 
     const commentBody = `
-    ## ${commentTitle}
-    ${markdown}
+## ${commentTitle}
+${markdown}
     `
     console.log(commentBody);
 

--- a/index.js
+++ b/index.js
@@ -12,21 +12,31 @@ const doesPathExists = path => {
   }
 }
 
-const validatePercentage = percentage => {
-  if (percentage != 0 && !percentage) {
-    return percentage
-  }
+function createDiffRows(diffSection) {
+  return diffSection.map((row) => (createDiffRow(row)));
+}
 
-  const value = Number(percentage)
-  if (isNaN(value) || !isFinite(value)) {
-    throw new Error(`unable to parse announcement threshold percentage as a number`)
-  }
-
-  return value
+function createDiffRow(data) {
+  return [
+    data.name,
+    fileSize(data.oldSize),
+    fileSize(data.newSize), 
+    `${fileSize(data.diff)} (${data.diffPercentage.toFixed(2)}%)`
+  ];
 }
 
 async function run() {
   try {
+    let extensions = core.getInput('extensions');
+    if (extensions) {
+      extensions = extensions.split(',');
+    }
+
+    const threshold = Number(core.getInput('threshold'));
+    const commentTitle = core.getInput('comment_title') || 'Bundle difference'
+    const all = core.getInput('all') === 'true';
+
+    
     const statsPaths = {
       base: core.getInput('base_stats_path'),
       head: core.getInput('head_stats_path')
@@ -45,54 +55,48 @@ async function run() {
       head: require(paths.head).assets
     }
 
-    const diff = getStatsDiff(assets.base, assets.head, {})
+    const diff = getStatsDiff(assets.base, assets.head, {extensions, threshold})
 
-    const announcementThresholds = {
-      increase: validatePercentage(core.getInput('announcement_percentage_threshold_increase')),
-      decrease: validatePercentage(core.getInput('announcement_percentage_threshold_decrease')),
-    }
+    console.log(diff);
 
-    if (announcementThresholds.increase != null && diff.total.diffPercentage >= 0 && (diff.total.diffPercentage < announcementThresholds.increase || (diff.total.diffPercentage == 0 && announcementThresholds.increase == 0))) {
-      console.log(`skipping adding comment because diff percentage ${diff.total.diffPercentage} is under the increase threshold of ${announcementThresholds.increase}`)
-      return
-    }
-
-    if (announcementThresholds.decrease != null && diff.total.diffPercentage <= 0 && (diff.total.diffPercentage > announcementThresholds.decrease || (diff.total.diffPercentage == 0 && announcementThresholds.decrease == 0))) {
-      console.log(`skipping adding comment because diff percentage ${diff.total.diffPercentage} is under the decrease threshold of ${announcementThresholds.decrease}`)
-      return
-    }
-
-    const summaryTable = markdownTable([
+    const markdown = markdownTable([
       [
+        'Name',
         'Old size',
         'New size',
         'Diff'
       ],
-      [
-        fileSize(diff.total.oldSize),
-        fileSize(diff.total.newSize), 
-        `${fileSize(diff.total.diff)} (${diff.total.diffPercentage.toFixed(2)}%)`
-      ]
-    ])
-    
+      createDiffRow(diff.total),
+      ...createDiffRows(diff.added),
+      ...createDiffRows(diff.bigger),
+      ...createDiffRows(diff.smaller),
+      ...createDiffRows(diff.removed),
+      ...(all ? createDiffRows(diff.sameSize) : [])
+    ]);
+
+    const commentBody = `
+    ## ${commentTitle}
+    ${markdown}
+    `
+    console.log(commentBody);
+
+
     /**
      * Publish a comment in the PR with the diff result.
      */
-    const octokit = github.getOctokit(core.getInput('token'))
+     const octokit = github.getOctokit(core.getInput('token'))
 
-    const pullRequestId = github.context.issue.number
-    if (!pullRequestId) {
-      throw new Error('Cannot find the PR id.')
-    }
+     const pullRequestId = github.context.issue.number
+     if (!pullRequestId) {
+       throw new Error('Cannot find the PR id.')
+     }
 
-    const commentTitle = core.getInput('comment_title') || 'Bundle difference'
+
     await octokit.issues.createComment({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
       issue_number: pullRequestId,
-      body: `## ${commentTitle}
-${summaryTable}
-`
+      body: commentBody
     })
   }
   catch (error) {


### PR DESCRIPTION
Whoops, meant to make this on my own fork. I'd be happy to merge these changes which mostly center around displaying a breakdown of percentages changed file-by-file, but they are a bit opinionated, so I understand if they aren't ideal. I'm planning on merging these changes on my fork and offering that as an alternative action, though I wish GHA would allow for private actions already